### PR TITLE
Refactor EmailTemplateMail to use emailImageUrl helper

### DIFF
--- a/src/App/Mail/EmailTemplateMail.php
+++ b/src/App/Mail/EmailTemplateMail.php
@@ -120,18 +120,18 @@ class EmailTemplateMail extends Mailable
             with: [
                 'subject' => $this->parseContent($this->template->subject ?? 'No Subject'),
 
-                'header_image' => $this->parseContent($this->resolveHeader('header_image')),
+                'header_image' => $this->emailImageUrl($this->resolveHeader('header_image')),
                 'header_text' => $this->parseContent($this->resolveHeader('header_text')),
-                'header_text_color' => $this->parseContent($this->resolveHeader('header_text_color')),
-                'header_background_color' => $this->parseContent($this->resolveHeader('header_background_color')),
+                'header_text_color' => $this->resolveHeader('header_text_color'),
+                'header_background_color' => $this->resolveHeader('header_background_color'),
 
                 'body' => $this->parseContent($this->template->body ?? ''),
 
-                'footer_image' => $this->parseContent($this->resolveFooter('footer_image')),
+                'footer_image' => $this->emailImageUrl($this->resolveFooter('footer_image')),
                 'footer_text' => $this->parseContent($this->resolveFooter('footer_text')),
-                'footer_text_color' => $this->parseContent($this->resolveFooter('footer_text_color')),
-                'footer_background_color' => $this->parseContent($this->resolveFooter('footer_background_color')),
-                'footer_bottom_image' => $this->parseContent($this->resolveFooter('footer_bottom_image')),
+                'footer_text_color' => $this->resolveFooter('footer_text_color'),
+                'footer_background_color' => $this->resolveFooter('footer_background_color'),
+                'footer_bottom_image' => $this->emailImageUrl($this->resolveFooter('footer_bottom_image')),
             ]
         );
     }
@@ -212,6 +212,20 @@ class EmailTemplateMail extends Mailable
         'footer_bottom_image' => 'globalFooterBottomImage',
     ];
 
+    protected function emailImageUrl(?string $path): ?string
+    {
+        if (! $path) {
+            return null;
+        }
+
+        // Already absolute (future-proof)
+        if (str_starts_with($path, 'http')) {
+            return $path;
+        }
+
+        // Storage::url() → /storage/...
+        return rtrim(config('app.url'), '/') . Storage::url($path);
+    }
     protected function resolveHeader(string $field)
     {
         if ($this->template->usesGlobalHeader()) {

--- a/src/views/emails/template.blade.php
+++ b/src/views/emails/template.blade.php
@@ -19,7 +19,7 @@
                 <tr>
                     <td align="center" style="padding:0; margin:0;">
                         <img
-                            src="{{ asset($header_image) }}"
+                            src="{{ $header_image }}"
                             width="600"
                             style="display:block; width:100%; max-width:600px; height:auto; border:0; outline:none; text-decoration:none;"
                             alt="Header Image"
@@ -69,7 +69,7 @@
                 <tr>
                     <td align="center" style="padding:0; margin:0;">
                         <img
-                            src="{{ asset($footer_image) }}"
+                            src="{{ $footer_image }}"
                             width="600"
                             style="display:block; width:100%; max-width:600px; height:auto; border:0; outline:none; text-decoration:none;"
                             alt="Footer Image"
@@ -103,7 +103,7 @@
                 <tr>
                     <td align="center" style="padding:0; margin:0;">
                         <img
-                            src="{{ asset($footer_bottom_image) }}"
+                            src="{{ $footer_bottom_image }}"
                             width="600"
                             style="display:block; width:100%; max-width:600px; height:auto; border:0; outline:none; text-decoration:none;"
                             alt="Footer Bottom Image"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed image URL resolution in email templates to properly normalize and display header, footer, and footer bottom images.
* Improved color value handling for header and footer colors in email templates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->